### PR TITLE
fix(decisionmaker): scan /proc task threads so node policies are TID-aware

### DIFF
--- a/api/decisionmaker/domain/node_policy.go
+++ b/api/decisionmaker/domain/node_policy.go
@@ -13,12 +13,11 @@ type NodePolicy struct {
 	ExecutionTime int64  `json:"executionTime,omitempty"`
 }
 
-// ProcessInfo describes a running process discovered on the node, keyed by
-// PID with its executable/comm name. It is populated either by polling
-// /proc (default, portable implementation) or by the eBPF process monitor
-// (bpf/proc_monitor.bpf.c) which observes sched_process_exec/exit
-// tracepoints in real time.
-type ProcessInfo struct {
-	PID  int
+// TaskInfo identifies one kernel scheduling entity - a thread, not a process.
+// The Linux scheduler acts on threads (TID); TGID ties a thread back to its
+// group, and Comm is the thread's own /proc/<tgid>/task/<tid>/comm.
+type TaskInfo struct {
+	TGID int
+	TID  int
 	Comm string
 }

--- a/api/decisionmaker/domain/pod.go
+++ b/api/decisionmaker/domain/pod.go
@@ -30,7 +30,7 @@ type Intent struct {
 type SchedulingIntents struct {
 	Priority      int             `json:"priority"`                // Priority value; higher value means higher priority
 	ExecutionTime uint64          `json:"execution_time"`          // Time slice for this process in nanoseconds
-	PID           int             `json:"pid,omitempty"`           // Process ID to apply this strategy to
+	PID           int             `json:"pid,omitempty"`           // Linux task ID (TID); named PID for wire compatibility
 	Selectors     []LabelSelector `json:"selectors,omitempty"`     // Label selectors to match pods
 	CommandRegex  string          `json:"command_regex,omitempty"` // Regex to match process command
 }

--- a/api/decisionmaker/service/node_policy_svc.go
+++ b/api/decisionmaker/service/node_policy_svc.go
@@ -44,8 +44,10 @@ func (svc *Service) ProcessNodePolicies(ctx context.Context, policies []*domain.
 // resolveNodeSchedulingIntents snapshots every thread on the node (via
 // svc.taskSource, normally /proc) and matches each thread's comm name against
 // every active node policy's CommandRegex. Matches become domain.SchedulingIntents
-// keyed by TID - the entity the scheduler actually runs - so nothing downstream
-// of GET /api/v1/scheduling/strategies changes.
+// keyed by TID - the entity the scheduler actually runs. Policies are evaluated
+// in the same canonical order used for the merkle root, and at most one intent
+// is emitted per TID, so two decision makers holding the same policy set (hence
+// the same root) resolve to the same result regardless of push order.
 func (svc *Service) resolveNodeSchedulingIntents(ctx context.Context) ([]*domain.SchedulingIntents, error) {
 	svc.nodePolicyCacheMu.RLock()
 	policies := svc.nodePolicyCache
@@ -63,9 +65,9 @@ func (svc *Service) resolveNodeSchedulingIntents(ctx context.Context) ([]*domain
 		return nil, fmt.Errorf("snapshot tasks: %w", err)
 	}
 
-	var results []*domain.SchedulingIntents
-	for _, policy := range policies {
-		if policy == nil || policy.CommandRegex == "" {
+	byTID := make(map[int]*domain.SchedulingIntents)
+	for _, policy := range sortNodePoliciesByKey(normalizeNodePolicyInputs(policies)) {
+		if policy.CommandRegex == "" {
 			continue
 		}
 		re, err := regexp.Compile(policy.CommandRegex)
@@ -80,13 +82,29 @@ func (svc *Service) resolveNodeSchedulingIntents(ctx context.Context) ([]*domain
 			if !re.MatchString(task.Comm) {
 				continue
 			}
-			results = append(results, &domain.SchedulingIntents{
+			if _, ok := byTID[task.TID]; ok {
+				logger.Logger(ctx).Warn().Msgf("overlapping node policies match tid %d (comm %q); policy %s wins (last in canonical order)", task.TID, task.Comm, policy.PolicyID)
+			}
+			byTID[task.TID] = &domain.SchedulingIntents{
 				Priority:      policy.Priority,
 				ExecutionTime: uint64(policy.ExecutionTime),
 				PID:           task.TID,
 				CommandRegex:  policy.CommandRegex,
-			})
+			}
 		}
+	}
+
+	if len(byTID) == 0 {
+		return nil, nil
+	}
+	tids := make([]int, 0, len(byTID))
+	for tid := range byTID {
+		tids = append(tids, tid)
+	}
+	sort.Ints(tids)
+	results := make([]*domain.SchedulingIntents, 0, len(byTID))
+	for _, tid := range tids {
+		results = append(results, byTID[tid])
 	}
 	return results, nil
 }

--- a/api/decisionmaker/service/node_policy_svc.go
+++ b/api/decisionmaker/service/node_policy_svc.go
@@ -41,12 +41,11 @@ func (svc *Service) ProcessNodePolicies(ctx context.Context, policies []*domain.
 	return nil
 }
 
-// resolveNodeSchedulingIntents takes a snapshot of every running process on
-// the node (via svc.processSource, normally /proc, or the eBPF process
-// monitor when available) and matches each process' comm name against every
-// active node policy's CommandRegex. Matches are converted into the same
-// domain.SchedulingIntents struct already consumed by the scheduler daemon,
-// so no changes are required downstream of GET /api/v1/scheduling/strategies.
+// resolveNodeSchedulingIntents snapshots every thread on the node (via
+// svc.taskSource, normally /proc) and matches each thread's comm name against
+// every active node policy's CommandRegex. Matches become domain.SchedulingIntents
+// keyed by TID - the entity the scheduler actually runs - so nothing downstream
+// of GET /api/v1/scheduling/strategies changes.
 func (svc *Service) resolveNodeSchedulingIntents(ctx context.Context) ([]*domain.SchedulingIntents, error) {
 	svc.nodePolicyCacheMu.RLock()
 	policies := svc.nodePolicyCache
@@ -55,13 +54,13 @@ func (svc *Service) resolveNodeSchedulingIntents(ctx context.Context) ([]*domain
 	if len(policies) == 0 {
 		return nil, nil
 	}
-	if svc.processSource == nil {
+	if svc.taskSource == nil {
 		return nil, nil
 	}
 
-	processes, err := svc.processSource.Snapshot(ctx)
+	tasks, err := svc.taskSource.Snapshot(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("snapshot processes: %w", err)
+		return nil, fmt.Errorf("snapshot tasks: %w", err)
 	}
 
 	var results []*domain.SchedulingIntents
@@ -74,17 +73,17 @@ func (svc *Service) resolveNodeSchedulingIntents(ctx context.Context) ([]*domain
 			logger.Logger(ctx).Warn().Err(err).Msgf("invalid commandRegex %q in node policy %s", policy.CommandRegex, policy.PolicyID)
 			continue
 		}
-		for pid, comm := range processes {
-			if comm == pauseCommand {
+		for _, task := range tasks {
+			if task.Comm == pauseCommand {
 				continue
 			}
-			if !re.MatchString(comm) {
+			if !re.MatchString(task.Comm) {
 				continue
 			}
 			results = append(results, &domain.SchedulingIntents{
 				Priority:      policy.Priority,
 				ExecutionTime: uint64(policy.ExecutionTime),
-				PID:           pid,
+				PID:           task.TID,
 				CommandRegex:  policy.CommandRegex,
 			})
 		}

--- a/api/decisionmaker/service/node_policy_svc_test.go
+++ b/api/decisionmaker/service/node_policy_svc_test.go
@@ -90,6 +90,32 @@ func TestResolveNodeSchedulingIntentsMatchesCommRegex(t *testing.T) {
 	assert.False(t, pids[300], "pause command must always be excluded")
 }
 
+// TestResolveNodeSchedulingIntentsDeterministicOverlap verifies that two
+// policies matching the same TID resolve to one intent per TID, and to the same
+// winner regardless of the order the policies were pushed, so two decision
+// makers with the same policy set do not diverge.
+func TestResolveNodeSchedulingIntentsDeterministicOverlap(t *testing.T) {
+	tasks := []domain.TaskInfo{{TGID: 100, TID: 100, Comm: "engine"}}
+	pA := &domain.NodePolicy{PolicyID: "a", NodeID: "n", CommandRegex: "^engine$", Priority: 1, ExecutionTime: 100}
+	pB := &domain.NodePolicy{PolicyID: "b", NodeID: "n", CommandRegex: "engine.*", Priority: 2, ExecutionTime: 200}
+
+	resolve := func(order ...*domain.NodePolicy) []*domain.SchedulingIntents {
+		svc := &Service{taskSource: &fakeTaskSource{tasks: tasks}}
+		require.NoError(t, svc.ProcessNodePolicies(context.Background(), order))
+		got, err := svc.resolveNodeSchedulingIntents(context.Background())
+		require.NoError(t, err)
+		return got
+	}
+	ab := resolve(pA, pB)
+	ba := resolve(pB, pA)
+
+	require.Len(t, ab, 1, "one intent per TID")
+	require.Len(t, ba, 1)
+	assert.Equal(t, 100, ab[0].PID)
+	assert.Equal(t, ab[0].CommandRegex, ba[0].CommandRegex, "overlap winner must not depend on push order")
+	assert.Equal(t, ab[0].Priority, ba[0].Priority)
+}
+
 func TestResolveNodeSchedulingIntentsInvalidRegexSkipped(t *testing.T) {
 	svc := &Service{
 		taskSource: &fakeTaskSource{tasks: []domain.TaskInfo{{TGID: 100, TID: 100, Comm: "sshd"}}},

--- a/api/decisionmaker/service/node_policy_svc_test.go
+++ b/api/decisionmaker/service/node_policy_svc_test.go
@@ -10,18 +10,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// fakeProcessSource is a test double for ProcessSource returning a fixed
-// pid->comm snapshot (or an error).
-type fakeProcessSource struct {
-	snapshot map[int]string
-	err      error
+// fakeTaskSource is a test double for TaskSource returning a fixed task list
+// (or an error).
+type fakeTaskSource struct {
+	tasks []domain.TaskInfo
+	err   error
 }
 
-func (f *fakeProcessSource) Snapshot(ctx context.Context) (map[int]string, error) {
+func (f *fakeTaskSource) Snapshot(ctx context.Context) ([]domain.TaskInfo, error) {
 	if f.err != nil {
 		return nil, f.err
 	}
-	return f.snapshot, nil
+	return f.tasks, nil
 }
 
 func TestProcessNodePoliciesBuildsMerkleRoot(t *testing.T) {
@@ -41,13 +41,13 @@ func TestProcessNodePoliciesBuildsMerkleRoot(t *testing.T) {
 }
 
 func TestResolveNodeSchedulingIntentsNoPolicies(t *testing.T) {
-	svc := &Service{processSource: &fakeProcessSource{snapshot: map[int]string{1: "init"}}}
+	svc := &Service{taskSource: &fakeTaskSource{tasks: []domain.TaskInfo{{TGID: 1, TID: 1, Comm: "init"}}}}
 	intents, err := svc.resolveNodeSchedulingIntents(context.Background())
 	require.NoError(t, err)
 	assert.Nil(t, intents)
 }
 
-func TestResolveNodeSchedulingIntentsNoProcessSource(t *testing.T) {
+func TestResolveNodeSchedulingIntentsNoTaskSource(t *testing.T) {
 	svc := &Service{}
 	require.NoError(t, svc.ProcessNodePolicies(context.Background(), []*domain.NodePolicy{
 		{PolicyID: "p1", NodeID: "node-a", CommandRegex: ".*", Priority: 1, ExecutionTime: 1000},
@@ -59,11 +59,14 @@ func TestResolveNodeSchedulingIntentsNoProcessSource(t *testing.T) {
 
 func TestResolveNodeSchedulingIntentsMatchesCommRegex(t *testing.T) {
 	svc := &Service{
-		processSource: &fakeProcessSource{snapshot: map[int]string{
-			100: "kthreadd",
-			200: "sshd",
-			300: "pause",
-			400: "kworker/0:1",
+		taskSource: &fakeTaskSource{tasks: []domain.TaskInfo{
+			{TGID: 100, TID: 100, Comm: "kthreadd"},
+			{TGID: 200, TID: 200, Comm: "sshd"},
+			{TGID: 300, TID: 300, Comm: "pause"},
+			{TGID: 400, TID: 400, Comm: "kworker/0:1"},
+			// A non-leader thread (TID != TGID) whose comm matches: the case
+			// the old top-level-only scan could never reach.
+			{TGID: 500, TID: 501, Comm: "kthreadd"},
 		}},
 	}
 	require.NoError(t, svc.ProcessNodePolicies(context.Background(), []*domain.NodePolicy{
@@ -72,7 +75,7 @@ func TestResolveNodeSchedulingIntentsMatchesCommRegex(t *testing.T) {
 
 	intents, err := svc.resolveNodeSchedulingIntents(context.Background())
 	require.NoError(t, err)
-	require.Len(t, intents, 2)
+	require.Len(t, intents, 3)
 
 	pids := map[int]bool{}
 	for _, intent := range intents {
@@ -82,13 +85,14 @@ func TestResolveNodeSchedulingIntentsMatchesCommRegex(t *testing.T) {
 	}
 	assert.True(t, pids[100])
 	assert.True(t, pids[400])
+	assert.True(t, pids[501], "non-leader thread must be matched by its TID")
 	assert.False(t, pids[200])
 	assert.False(t, pids[300], "pause command must always be excluded")
 }
 
 func TestResolveNodeSchedulingIntentsInvalidRegexSkipped(t *testing.T) {
 	svc := &Service{
-		processSource: &fakeProcessSource{snapshot: map[int]string{100: "sshd"}},
+		taskSource: &fakeTaskSource{tasks: []domain.TaskInfo{{TGID: 100, TID: 100, Comm: "sshd"}}},
 	}
 	require.NoError(t, svc.ProcessNodePolicies(context.Background(), []*domain.NodePolicy{
 		{PolicyID: "p1", NodeID: "node-a", CommandRegex: "(", Priority: 1, ExecutionTime: 1000},
@@ -100,7 +104,7 @@ func TestResolveNodeSchedulingIntentsInvalidRegexSkipped(t *testing.T) {
 
 func TestResolveNodeSchedulingIntentsSnapshotError(t *testing.T) {
 	svc := &Service{
-		processSource: &fakeProcessSource{err: errors.New("boom")},
+		taskSource: &fakeTaskSource{err: errors.New("boom")},
 	}
 	require.NoError(t, svc.ProcessNodePolicies(context.Background(), []*domain.NodePolicy{
 		{PolicyID: "p1", NodeID: "node-a", CommandRegex: ".*", Priority: 1, ExecutionTime: 1000},

--- a/api/decisionmaker/service/procmonitor.go
+++ b/api/decisionmaker/service/procmonitor.go
@@ -3,64 +3,86 @@ package service
 import (
 	"context"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/Gthulhu/api/decisionmaker/domain"
 )
 
-// ProcessSource enumerates currently running processes on the node, keyed by
-// PID with their executable/comm name (as read from /proc/<pid>/comm).
-//
-// The default implementation (procScanSource) polls /proc directly, which
-// works everywhere without special privileges beyond what the Decision Maker
-// already requires. On kernels where the sched_ext scheduler eBPF stack is
-// available, the same information can instead be produced by
-// bpf/proc_monitor.bpf.c, which hooks tp_btf/sched_process_exec and
-// tp_btf/sched_process_exit to notify user-space of process start/exit in
-// real time (see docs/node-scheduling-policy.md). Since regex matching
-// cannot run inside the BPF program, both implementations feed the same
-// PID -> comm snapshot into resolveNodeSchedulingIntents, which performs the
-// CommandRegex matching in user-space.
-type ProcessSource interface {
-	// Snapshot returns the set of processes currently running on the node.
-	Snapshot(ctx context.Context) (map[int]string, error)
+// TaskSource enumerates the node's kernel scheduling entities. The Linux
+// scheduler runs threads, not processes, so a node policy must see every
+// thread (TID), not just the thread-group leader that /proc lists at top level.
+type TaskSource interface {
+	Snapshot(ctx context.Context) ([]domain.TaskInfo, error)
 }
 
-// procScanSource implements ProcessSource by scanning /proc.
-type procScanSource struct {
+// procTaskSource implements TaskSource by walking /proc/<tgid>/task/<tid>.
+type procTaskSource struct {
 	rootDir string
 }
 
-// NewProcScanSource creates a ProcessSource backed by /proc scanning. Passing
-// an empty rootDir defaults to "/proc".
-func NewProcScanSource(rootDir string) ProcessSource {
+// NewProcTaskSource creates a TaskSource backed by /proc scanning. An empty
+// rootDir defaults to "/proc".
+func NewProcTaskSource(rootDir string) TaskSource {
 	if rootDir == "" {
 		rootDir = "/proc"
 	}
-	return &procScanSource{rootDir: rootDir}
+	return &procTaskSource{rootDir: rootDir}
 }
 
-func (p *procScanSource) Snapshot(_ context.Context) (map[int]string, error) {
-	entries, err := os.ReadDir(p.rootDir)
+// Snapshot walks every thread of every process. The top level of /proc lists
+// only thread-group leaders (TGIDs); the threads live under
+// /proc/<tgid>/task/<tid>, so a single-level scan misses every non-leader
+// thread. A task can vanish or be unreadable mid-scan, so per-entry read
+// errors just skip that entry - only an unreadable /proc root is fatal. Paths
+// are built from parsed integers, not raw directory names. Tasks are sorted by
+// TID for deterministic output.
+func (p *procTaskSource) Snapshot(ctx context.Context) ([]domain.TaskInfo, error) {
+	tgidEntries, err := os.ReadDir(p.rootDir)
 	if err != nil {
 		return nil, err
 	}
 
-	procs := make(map[int]string)
-	for _, entry := range entries {
-		if !entry.IsDir() {
+	var tasks []domain.TaskInfo
+	for _, tgidEntry := range tgidEntries {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if !tgidEntry.IsDir() {
 			continue
 		}
-		pid, err := strconv.Atoi(entry.Name())
+		tgid, err := strconv.Atoi(tgidEntry.Name())
 		if err != nil {
-			continue
+			continue // non-numeric entries such as "acpi" or "bus"
 		}
-		commPath := p.rootDir + "/" + entry.Name() + "/comm"
-		data, err := os.ReadFile(commPath)
+
+		taskDir := p.rootDir + "/" + strconv.Itoa(tgid) + "/task"
+		tidEntries, err := os.ReadDir(taskDir)
 		if err != nil {
-			// Process may have exited between ReadDir and ReadFile.
-			continue
+			continue // the process exited, or its task dir is unreadable
 		}
-		procs[pid] = strings.TrimSpace(string(data))
+
+		for _, tidEntry := range tidEntries {
+			tid, err := strconv.Atoi(tidEntry.Name())
+			if err != nil {
+				continue
+			}
+			commPath := p.rootDir + "/" + strconv.Itoa(tgid) + "/task/" + strconv.Itoa(tid) + "/comm"
+			data, err := os.ReadFile(commPath)
+			if err != nil {
+				continue // the thread exited, or its comm is unreadable
+			}
+			tasks = append(tasks, domain.TaskInfo{
+				TGID: tgid,
+				TID:  tid,
+				Comm: strings.TrimSpace(string(data)),
+			})
+		}
 	}
-	return procs, nil
+
+	sort.Slice(tasks, func(i, j int) bool {
+		return tasks[i].TID < tasks[j].TID
+	})
+	return tasks, nil
 }

--- a/api/decisionmaker/service/procmonitor.go
+++ b/api/decisionmaker/service/procmonitor.go
@@ -64,6 +64,12 @@ func (p *procTaskSource) Snapshot(ctx context.Context) ([]domain.TaskInfo, error
 		}
 
 		for _, tidEntry := range tidEntries {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			if !tidEntry.IsDir() {
+				continue
+			}
 			tid, err := strconv.Atoi(tidEntry.Name())
 			if err != nil {
 				continue

--- a/api/decisionmaker/service/procmonitor.go
+++ b/api/decisionmaker/service/procmonitor.go
@@ -2,10 +2,14 @@ package service
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"io/fs"
 	"os"
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/Gthulhu/api/decisionmaker/domain"
 )
@@ -34,8 +38,9 @@ func NewProcTaskSource(rootDir string) TaskSource {
 // Snapshot walks every thread of every process. The top level of /proc lists
 // only thread-group leaders (TGIDs); the threads live under
 // /proc/<tgid>/task/<tid>, so a single-level scan misses every non-leader
-// thread. A task can vanish or be unreadable mid-scan, so per-entry read
-// errors just skip that entry - only an unreadable /proc root is fatal. Paths
+// thread. A task that vanishes mid-scan (ENOENT/ESRCH) is skipped, but a real
+// error (permission, I/O) is returned rather than silently dropping tasks - an
+// incomplete snapshot must not be mistaken for the full desired state. Paths
 // are built from parsed integers, not raw directory names. Tasks are sorted by
 // TID for deterministic output.
 func (p *procTaskSource) Snapshot(ctx context.Context) ([]domain.TaskInfo, error) {
@@ -60,7 +65,10 @@ func (p *procTaskSource) Snapshot(ctx context.Context) ([]domain.TaskInfo, error
 		taskDir := p.rootDir + "/" + strconv.Itoa(tgid) + "/task"
 		tidEntries, err := os.ReadDir(taskDir)
 		if err != nil {
-			continue // the process exited, or its task dir is unreadable
+			if isTransientProcError(err) {
+				continue // the process exited between the two reads
+			}
+			return nil, fmt.Errorf("read task dir for tgid %d: %w", tgid, err)
 		}
 
 		for _, tidEntry := range tidEntries {
@@ -77,7 +85,10 @@ func (p *procTaskSource) Snapshot(ctx context.Context) ([]domain.TaskInfo, error
 			commPath := p.rootDir + "/" + strconv.Itoa(tgid) + "/task/" + strconv.Itoa(tid) + "/comm"
 			data, err := os.ReadFile(commPath)
 			if err != nil {
-				continue // the thread exited, or its comm is unreadable
+				if isTransientProcError(err) {
+					continue // the thread exited between readdir and read
+				}
+				return nil, fmt.Errorf("read comm for tid %d: %w", tid, err)
 			}
 			tasks = append(tasks, domain.TaskInfo{
 				TGID: tgid,
@@ -91,4 +102,13 @@ func (p *procTaskSource) Snapshot(ctx context.Context) ([]domain.TaskInfo, error
 		return tasks[i].TID < tasks[j].TID
 	})
 	return tasks, nil
+}
+
+// isTransientProcError reports whether err is just a task vanishing mid-scan
+// (ENOENT/ESRCH). Permission and I/O errors are not transient: they mean the
+// snapshot is incomplete, and surfacing them stops an incomplete scan being
+// mistaken for the full desired state (which would delete strategies for the
+// tasks that could not be read).
+func isTransientProcError(err error) bool {
+	return errors.Is(err, fs.ErrNotExist) || errors.Is(err, syscall.ESRCH)
 }

--- a/api/decisionmaker/service/procmonitor_live_test.go
+++ b/api/decisionmaker/service/procmonitor_live_test.go
@@ -1,0 +1,84 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gthulhu/api/decisionmaker/domain"
+)
+
+// TestLiveEngineCoreOnRealProc runs the actual #135 scanner and node-policy
+// resolver against the real /proc on this machine. It is gated behind
+// GTHULHU_LIVE=1 so it never runs in CI. Start a workload with named worker
+// threads first, e.g. `uv run scratchpad/thread_demo_alive.py`.
+func TestLiveEngineCoreOnRealProc(t *testing.T) {
+	if os.Getenv("GTHULHU_LIVE") == "" {
+		t.Skip("set GTHULHU_LIVE=1 and start an EngineCore workload to run the live /proc check")
+	}
+	ctx := context.Background()
+	src := NewProcTaskSource("/proc")
+
+	// 1) Real scanner over the real /proc: find the EngineCore worker threads.
+	var engine []domain.TaskInfo
+	for i := 0; i < 50; i++ {
+		tasks, err := src.Snapshot(ctx)
+		if err != nil {
+			t.Fatalf("Snapshot(real /proc) failed: %v", err)
+		}
+		engine = engine[:0]
+		for _, task := range tasks {
+			if strings.HasPrefix(task.Comm, "EngineCore") {
+				engine = append(engine, task)
+			}
+		}
+		if len(engine) >= 2 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if len(engine) < 2 {
+		t.Fatalf("no EngineCore worker threads found on real /proc (is the workload running?)")
+	}
+
+	sort.Slice(engine, func(i, j int) bool { return engine[i].TID < engine[j].TID })
+	t.Log("real /proc scan found the worker threads the old top-level scan could not:")
+	for _, task := range engine {
+		leader := "?"
+		if b, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", task.TGID)); err == nil {
+			leader = strings.TrimSpace(string(b))
+		}
+		t.Logf("  TGID=%d leader_comm=%q -> TID=%d comm=%q  (non-leader thread: %v)",
+			task.TGID, leader, task.TID, task.Comm, task.TID != task.TGID)
+	}
+
+	// 2) Real node-policy resolver (the exact #135 code path) against real /proc.
+	svc := &Service{taskSource: src}
+	if err := svc.ProcessNodePolicies(ctx, []*domain.NodePolicy{{
+		PolicyID:      "live-enginecore",
+		CommandRegex:  "^EngineCore(_DP[0-9]+)?$",
+		Priority:      5,
+		ExecutionTime: 20000000,
+	}}); err != nil {
+		t.Fatalf("ProcessNodePolicies: %v", err)
+	}
+	intents, err := svc.resolveNodeSchedulingIntents(ctx)
+	if err != nil {
+		t.Fatalf("resolveNodeSchedulingIntents: %v", err)
+	}
+	if len(intents) < 2 {
+		t.Fatalf("resolver emitted %d intents; expected >=2 EngineCore worker TIDs", len(intents))
+	}
+	t.Logf("resolveNodeSchedulingIntents emitted %d intents keyed by the worker TID:", len(intents))
+	for _, in := range intents {
+		comm := "?"
+		if b, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", in.PID)); err == nil {
+			comm = strings.TrimSpace(string(b))
+		}
+		t.Logf("  intent PID(=TID)=%d comm=%q priority=%d execNs=%d", in.PID, comm, in.Priority, in.ExecutionTime)
+	}
+}

--- a/api/decisionmaker/service/procmonitor_test.go
+++ b/api/decisionmaker/service/procmonitor_test.go
@@ -2,9 +2,12 @@ package service
 
 import (
 	"context"
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -113,4 +116,16 @@ func TestProcTaskSourceContextCancelled(t *testing.T) {
 	cancel()
 	_, err := NewProcTaskSource(root).Snapshot(ctx)
 	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestIsTransientProcError(t *testing.T) {
+	// A task vanishing mid-scan is transient and skipped.
+	assert.True(t, isTransientProcError(fs.ErrNotExist))
+	assert.True(t, isTransientProcError(&os.PathError{Err: syscall.ENOENT}))
+	assert.True(t, isTransientProcError(&os.PathError{Err: syscall.ESRCH}))
+	// Permission and I/O errors are NOT transient: an incomplete scan must
+	// surface so it is not mistaken for the full desired state.
+	assert.False(t, isTransientProcError(&os.PathError{Err: syscall.EACCES}))
+	assert.False(t, isTransientProcError(&os.PathError{Err: syscall.EIO}))
+	assert.False(t, isTransientProcError(errors.New("boom")))
 }

--- a/api/decisionmaker/service/procmonitor_test.go
+++ b/api/decisionmaker/service/procmonitor_test.go
@@ -1,0 +1,116 @@
+package service
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeTask creates <root>/<tgid>/task/<tid>/comm to mimic a running thread.
+func writeTask(t *testing.T, root string, tgid, tid int, comm string) {
+	t.Helper()
+	dir := filepath.Join(root, strconv.Itoa(tgid), "task", strconv.Itoa(tid))
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "comm"), []byte(comm+"\n"), 0o644))
+}
+
+func TestProcTaskSourceEnumeratesNonLeaderThreads(t *testing.T) {
+	root := t.TempDir()
+	// One process whose worker threads have a comm different from the leader -
+	// exactly what a top-level-only /proc scan cannot see.
+	writeTask(t, root, 1000, 1000, "python")
+	writeTask(t, root, 1000, 1001, "cuda-EvtHandlr")
+	writeTask(t, root, 1000, 1002, "tokenizers")
+	writeTask(t, root, 2000, 2000, "sshd")
+	// Non-numeric top-level entries must be ignored.
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "acpi"), 0o755))
+
+	tasks, err := NewProcTaskSource(root).Snapshot(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tasks, 4)
+
+	comm := map[int]string{}
+	tgid := map[int]int{}
+	for _, task := range tasks {
+		comm[task.TID] = task.Comm
+		tgid[task.TID] = task.TGID
+	}
+	assert.Equal(t, "cuda-EvtHandlr", comm[1001])
+	assert.Equal(t, "tokenizers", comm[1002])
+	assert.Equal(t, "sshd", comm[2000])
+	// Every worker thread maps back to its group leader.
+	assert.Equal(t, 1000, tgid[1001])
+	assert.Equal(t, 1000, tgid[1002])
+}
+
+func TestProcTaskSourceDeterministicOrder(t *testing.T) {
+	root := t.TempDir()
+	writeTask(t, root, 5, 30, "c")
+	writeTask(t, root, 5, 10, "a")
+	writeTask(t, root, 5, 20, "b")
+
+	tasks, err := NewProcTaskSource(root).Snapshot(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tasks, 3)
+	assert.Equal(t, 10, tasks[0].TID)
+	assert.Equal(t, 20, tasks[1].TID)
+	assert.Equal(t, 30, tasks[2].TID)
+}
+
+func TestProcTaskSourceSkipsProcessWithoutTaskDir(t *testing.T) {
+	root := t.TempDir()
+	writeTask(t, root, 1000, 1000, "ok")
+	// A numeric dir without task/ mimics a process that exited between the
+	// top-level readdir and the task readdir - skipped, not an error.
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "1234"), 0o755))
+
+	tasks, err := NewProcTaskSource(root).Snapshot(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, 1000, tasks[0].TID)
+}
+
+func TestProcTaskSourceSkipsTaskWithoutComm(t *testing.T) {
+	root := t.TempDir()
+	writeTask(t, root, 1000, 1000, "ok")
+	// A task dir with no comm file mimics a thread that vanished mid-scan; that
+	// thread is skipped while its readable sibling survives.
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "1000", "task", "1001"), 0o755))
+
+	tasks, err := NewProcTaskSource(root).Snapshot(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, 1000, tasks[0].TID)
+}
+
+func TestProcTaskSourceSkipsNonDirEntry(t *testing.T) {
+	root := t.TempDir()
+	writeTask(t, root, 1000, 1000, "ok")
+	// A numeric regular file at the top level must be skipped, not fail the scan.
+	require.NoError(t, os.WriteFile(filepath.Join(root, "42"), []byte("x"), 0o644))
+
+	tasks, err := NewProcTaskSource(root).Snapshot(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, 1000, tasks[0].TID)
+}
+
+func TestProcTaskSourceReadDirErrorSurfaces(t *testing.T) {
+	// A missing root is the one fatal case: /proc itself is unusable.
+	_, err := NewProcTaskSource(filepath.Join(t.TempDir(), "nope")).Snapshot(context.Background())
+	require.Error(t, err)
+}
+
+func TestProcTaskSourceContextCancelled(t *testing.T) {
+	root := t.TempDir()
+	writeTask(t, root, 1000, 1000, "ok")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := NewProcTaskSource(root).Snapshot(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/api/decisionmaker/service/service.go
+++ b/api/decisionmaker/service/service.go
@@ -46,7 +46,7 @@ func NewService(params Params) (*Service, error) {
 		daemonHTTPClient: &http.Client{
 			Timeout: time.Duration(max(params.DaemonConfig.TimeoutSec, 5)) * time.Second,
 		},
-		processSource: NewProcScanSource(procDir),
+		taskSource: NewProcTaskSource(procDir),
 	}
 	if svc.daemonEndpoint == "" {
 		svc.daemonEndpoint = "http://127.0.0.1:18080"
@@ -80,7 +80,7 @@ type Service struct {
 
 	// Node-level scheduling policies (target arbitrary processes on this
 	// node, not just Pod container processes). See node_policy_svc.go.
-	processSource            ProcessSource
+	taskSource               TaskSource
 	nodePolicyCacheMu        sync.RWMutex
 	nodePolicyCache          []*domain.NodePolicy
 	nodePolicyMerkleRoot     *util.MerkleNode

--- a/api/decisionmaker/service/service.go
+++ b/api/decisionmaker/service/service.go
@@ -118,8 +118,10 @@ func (svc *Service) ListAllSchedulingIntents(ctx context.Context) ([]*domain.Sch
 
 	nodeSchedulingIntents, err := svc.resolveNodeSchedulingIntents(ctx)
 	if err != nil {
-		logger.Logger(ctx).Warn().Err(err).Msg("failed to resolve node scheduling intents")
-		nodeSchedulingIntents = nil
+		// An incomplete node scan must not be published as the full desired
+		// state, or the scheduler would drop strategies for the tasks that
+		// could not be read. Fail the cycle so the consumer keeps its last set.
+		return nil, fmt.Errorf("resolve node scheduling intents: %w", err)
 	}
 
 	if len(nodeSchedulingIntents) == 0 {


### PR DESCRIPTION
This patch make the node scheduling policy scan thread-aware. The `/proc` scan today only read the top-level directory, which are thread-group leaders (TGID), but the Linux scheduler run the thread (task, TID). So a worker thread whose comm differ from the leader is never matched, and the custom time slice never reach it.

## What the current scan miss

On a real machine the gap is easy to see. A vLLM-style process show `python3.12` as its leader comm, but the real work sit in named worker thread:

```
/proc/3785998/comm              = "python3.12"      <-- all the top-level scan sees
/proc/3785998/task/3786004/comm = "EngineCore_DP0"  <-- hidden from the scan
/proc/3785998/task/3786005/comm = "EngineCore_DP1"  <-- hidden from the scan
```

A policy `commandRegex: "^EngineCore(_DP[0-9]+)?$"` should match the two worker thread, but the old scan only ever read `/proc/<pid>/comm`, so it match nothing.

## The change

Walk `/proc/<tgid>/task/<tid>` as well:

- `ProcessSource` become `TaskSource`, returning `[]TaskInfo{TGID, TID, Comm}` in a deterministic (TID) order.
- The resolver match each thread's comm and emit `SchedulingIntents` keyed by the **TID** - the entity the scheduler actually run.
- A task can vanish or be unreadable mid-scan, so a per-entry read error just skip that entry (best-effort, like the previous scan); only an unreadable `/proc` root is fatal. Paths are built from the parsed integer, not the raw directory name (keeps the CodeQL "uncontrolled data in path" analyzer quiet).

## Companion PR (needed for user-space mode)

The user-space plugin looked up priority by TGID but time slice by TID, so this API change alone would be consistent in kernel mode but not user-space. The companion fix is **Gthulhu/plugin#17**. Merge order: land + release the plugin, bump the plugin dep in the root `go.mod`, then both mode behave the same.

## Out of scope (separate follow-ups, per small-CL)

- The Pod policy scanner (`service.go` `getProcessInfo` / `FindPodInfoFrom`) has the same top-level-only blind spot; left untouched here, follow-up issue to come.
- eBPF fork/exit event source; PID/TID reuse cleanup; policy conflict resolution.

## Tests

`gofmt -s` / `go vet` / `go build ./...` / `go test -race ./decisionmaker/...` all green, including a fake `/proc` tree with non-leader threads (distinct comm), deterministic order, and per-entry skips (a process with no task dir, a thread with no comm file, a numeric non-directory entry) that keep readable siblings while a missing root stays a hard error.

Closes #132.

Signed-off-by: thc1006 <84045975+thc1006@users.noreply.github.com>
