### PR TITLE
fix(scheduler): don't insert non-boosting (Priority<=0) strategies as priority 0 in kernel mode

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -243,6 +243,16 @@ func Run(args []string) error {
 			changed, removed := p.GetChangedStrategies()
 			if len(changed) > 0 || len(removed) > 0 {
 				for _, strategy := range changed {
+					if strategy.Priority <= 0 {
+						// qumun treats priority 0 as the highest, preemptive level
+						// and has no slice-only state, so a non-boosting rule must
+						// not be inserted (that would promote the task, the opposite
+						// of user-space). Drop any stale entry instead.
+						if rmErr := bpfModule.RemovePriorityTask(uint32(strategy.PID)); rmErr != nil {
+							slog.Warn("RemovePriorityTask (non-positive priority) failed", "error", rmErr, "pid", strategy.PID)
+						}
+						continue
+					}
 					err = bpfModule.UpdatePriorityTaskWithPrio(uint32(strategy.PID), strategy.ExecutionTime, uint32(strategy.Priority))
 					if err != nil {
 						slog.Warn("UpdatePriorityTaskWithPrio failed", "error", err, "pid", strategy.PID)


### PR DESCRIPTION
This patch fix a kernel / user-space mismatch. After Gthulhu/plugin#17, a `Priority == 0` strategy in user-space mean "custom slice, no boost" (it does not jump the run queue). But in kernel mode the daemon pass every changed strategy's priority straight to `UpdatePriorityTaskWithPrio`, and qumun's `priority_tasks` treat priority **0 as the highest, preemptive level**. So the same `{priority: 0}` had the opposite effect depending on `kernel_mode`.

## The change

In the kernel-mode apply loop (`internal/scheduler/scheduler.go`), skip `Priority <= 0`: a non-boosting rule is not inserted, and any stale entry for that task is removed, so priority 0 no longer promote the task.

## Note (not claiming full parity)

kernel mode still have no "custom slice at normal priority" state — qumun couple slice and priority in a single map — so a slice-only rule currently has **no** effect in kernel mode, rather than the wrong effect. Making kernel mode fully honour slice-only rules (a qumun change) and canonicalising the priority scale across REST / user-space / qumun are tracked as follow-ups. This PR only remove the dangerous priority-0 promotion.

`make build` pass (scheduler binary rebuilt).

Signed-off-by: thc1006 <84045975+thc1006@users.noreply.github.com>
