### PR TITLE
community: improve contributor onboarding and issue intake

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,68 @@
+name: Bug report
+description: Report a reproducible problem in Gthulhu
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Gthulhu. Please include enough environment information for maintainers to reproduce the issue.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: Describe the observed behavior and its impact.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How can we reproduce it?
+      description: Include the smallest reliable set of steps, manifests, or commands.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Gthulhu version or commit
+      placeholder: vX.Y.Z or commit SHA
+    validations:
+      required: true
+  - type: input
+    id: kubernetes
+    attributes:
+      label: Kubernetes version
+      placeholder: v1.xx.x
+  - type: input
+    id: kernel
+    attributes:
+      label: Linux kernel version
+      description: Required for sched_ext or eBPF-related problems.
+      placeholder: 6.12.x
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Deployment method, distro, container runtime, node topology, and other relevant details.
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or output
+      description: Remove credentials, tokens, private addresses, and other sensitive data before posting.
+      render: shell
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues for the same problem.
+          required: true
+        - label: I removed secrets and sensitive information from logs and manifests.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,61 @@
+name: Feature request
+description: Propose a new capability or improvement
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Gthulhu is use-case driven. Start with the workload or operational problem rather than a proposed implementation.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What workload, scheduling, observability, or scaling problem are you trying to solve?
+    validations:
+      required: true
+  - type: textarea
+    id: current
+    attributes:
+      label: Current approach
+      description: How do you solve this today, and what is missing?
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: Describe the behavior or outcome you want without prescribing an implementation when possible.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Kubernetes integration
+        - eBPF observability
+        - Linux sched_ext / CPU scheduling
+        - Autoscaling / KEDA
+        - Scheduling policy or intent
+        - CLI / UX
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Possible approach
+      description: Optional. Share implementation ideas, trade-offs, references, or prior art.
+  - type: textarea
+    id: contribution
+    attributes:
+      label: Contribution
+      description: Let us know if you are interested in implementing or testing this feature.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and roadmap discussions for similar requests.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## What does this PR change?
+
+<!-- Give a concise summary. -->
+
+## Why is this change needed?
+
+<!-- Link the issue/use case and explain the problem being solved. -->
+
+Closes #
+
+## How was it tested?
+
+<!-- Commands, environments, kernel/Kubernetes versions, screenshots, metrics, or other evidence. -->
+
+## Contributor checklist
+
+- [ ] The change is focused and does not include unrelated cleanup.
+- [ ] Tests were added or updated when behavior changed.
+- [ ] Documentation was updated when user-facing behavior changed.
+- [ ] Relevant local/CI checks pass.
+- [ ] No secrets or sensitive environment data are included.
+
+## Scheduling / eBPF changes
+
+<!-- If applicable, describe kernel versions tested, sched_ext behavior, performance implications, verifier concerns, or compatibility risks. Otherwise write N/A. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,65 @@
-Please refer to https://gthulhu.org/contributing/
+# Contributing to Gthulhu
+
+Thanks for your interest in Gthulhu. Contributions of code, documentation, testing, bug reports, use cases, and design feedback are welcome.
+
+Gthulhu sits at the intersection of Kubernetes workload orchestration, eBPF observability, autoscaling, and Linux `sched_ext`. You do not need to understand every layer of the stack before contributing.
+
+## Start here
+
+1. Read the project overview in [README.md](README.md).
+2. Check the [open issues](https://github.com/Gthulhu/Gthulhu/issues) for work that matches your interests.
+3. If you are new to the project, look for issues labeled `good first issue` or `help wanted`.
+4. For a larger change, open an issue first so we can align on the problem and approach before implementation.
+
+The full contributor documentation is also available at [gthulhu.org/contributing](https://gthulhu.org/contributing/).
+
+## Areas where you can contribute
+
+- **Kubernetes integration** — controllers, CRDs, scheduling intents, Helm packaging, and deployment experience.
+- **eBPF observability** — scheduling metrics, tracing, portability, and performance analysis.
+- **Linux `sched_ext`** — custom CPU scheduling policies, scheduler experiments, and kernel compatibility.
+- **Autoscaling** — KEDA integration and workload-aware scaling strategies.
+- **Testing and portability** — validation across supported Linux kernel versions and Kubernetes environments.
+- **Documentation and examples** — tutorials, architecture explanations, demos, and real-world use cases.
+
+## Development workflow
+
+Fork the repository, create a focused branch, make your changes, and open a pull request against `main`.
+
+Before submitting a PR:
+
+- keep the change focused on one problem;
+- add or update tests when behavior changes;
+- update documentation when user-facing behavior changes;
+- run the relevant checks described in the README/Makefile;
+- explain both **what** changed and **why** in the PR description.
+
+## Issues
+
+A useful bug report should include:
+
+- Gthulhu version or commit;
+- Kubernetes version;
+- Linux kernel version, especially for `sched_ext`-related issues;
+- deployment method;
+- steps to reproduce;
+- expected and actual behavior;
+- relevant logs or metrics with secrets removed.
+
+For feature requests, describe the workload or operational problem first. Concrete use cases help maintainers evaluate whether a proposed feature belongs in Gthulhu.
+
+## Pull requests
+
+Small, reviewable PRs are preferred. If your change introduces a new scheduling policy, API, architecture dependency, or significant behavior change, link the design discussion or issue that motivated it.
+
+Please avoid drive-by changes that only reformat unrelated code or documentation.
+
+## Community expectations
+
+Participation in the Gthulhu community is governed by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+For security vulnerabilities, do **not** open a public issue. Follow [SECURITY.md](SECURITY.md) instead.
+
+## Questions
+
+If you are unsure where to start, open a GitHub issue or join the community channels listed in the README. Tell us what area you are interested in and what environment you can test on; maintainers can help identify a useful first contribution.


### PR DESCRIPTION
## Summary

This is the first repository-readiness pass focused on making it easier for new contributors to enter the Gthulhu community and for maintainers to receive actionable issues and PRs.

### Changes

- expand `CONTRIBUTING.md` from a single external link into a useful repository-native onboarding guide;
- add a structured bug report template with Kubernetes/kernel/environment context;
- add a use-case-driven feature request template;
- add a PR template with testing and `sched_ext`/eBPF compatibility prompts.

## Why

Gthulhu spans Kubernetes, eBPF, KEDA, and Linux `sched_ext`, which creates a relatively high context barrier for first-time contributors. These changes make contribution paths explicit without requiring newcomers to understand the entire architecture first.

This PR intentionally focuses on contributor funnel quality. Follow-up work can cover project positioning, governance/maturity documentation, curated `good first issue` tasks, and CNCF-readiness gaps.

Related roadmap: #141